### PR TITLE
This should fix the list concatenation bug

### DIFF
--- a/grammar.jison
+++ b/grammar.jison
@@ -249,7 +249,7 @@ expression
 
 // XXX: introduces a TON of SR conflicts and I have no idea why!
     | expression '//' expression
-        { $$ = $1 + ' + ' + $3; }
+        { $$ = $1 + '.concat(' + $3 +')'; }
 
     //
     // assignment operators

--- a/js/eden/parser.js
+++ b/js/eden/parser.js
@@ -79,7 +79,7 @@ case 32: this.$ = '' + $$[$0-2] + ' || ' + $$[$0];
 break;
 case 33: this.$ = '' + $$[$0-2] + ' || ' + $$[$0]; 
 break;
-case 34: this.$ = $$[$0-2] + ' + ' + $$[$0]; 
+case 34: this.$ = $$[$0-2] + '.concat(' + $$[$0] +')'; 
 break;
 case 35: this.$ = $$[$0-2] + '.assign(' + $$[$0] + ', this).value()'; 
 break;
@@ -283,7 +283,7 @@ parse: function parse(input) {
             token = self.symbols_[token] || token;
         }
         return token;
-    };
+    }
 
     var symbol, preErrorSymbol, state, action, a, r, yyval={},p,len,newState, expected;
     while (true) {
@@ -301,6 +301,7 @@ parse: function parse(input) {
         }
 
         // handle parse error
+        _handle_error:
         if (typeof action === 'undefined' || !action.length || !action[0]) {
 
             if (!recovering) {
@@ -311,7 +312,7 @@ parse: function parse(input) {
                 }
                 var errStr = '';
                 if (this.lexer.showPosition) {
-                    errStr = 'Parse error on line '+(yylineno+1)+":\n"+this.lexer.showPosition()+'\nExpecting '+expected.join(', ') + ", got '" + this.terminals_[symbol]+ "'";
+                    errStr = 'Parse error on line '+(yylineno+1)+":\n"+this.lexer.showPosition()+"\nExpecting "+expected.join(', ') + ", got '" + this.terminals_[symbol]+ "'";
                 } else {
                     errStr = 'Parse error on line '+(yylineno+1)+": Unexpected " +
                                   (symbol == 1 /*EOF*/ ? "end of input" :
@@ -539,6 +540,12 @@ popState:function popState() {
     },
 _currentRules:function _currentRules() {
         return this.conditions[this.conditionStack[this.conditionStack.length-1]].rules;
+    },
+topState:function () {
+        return this.conditionStack[this.conditionStack.length-2];
+    },
+pushState:function begin(condition) {
+        this.begin(condition);
     }});
 lexer.performAction = function anonymous(yy,yy_,$avoiding_name_collisions,YY_START) {
 
@@ -726,7 +733,7 @@ exports.main = function commonjsMain(args) {
     if (!args[1])
         throw new Error('Usage: '+args[0]+' FILE');
     if (typeof process !== 'undefined') {
-        var source = require("fs").readFileSync(require("path").join(process.cwd(), args[1]), "utf8");
+        var source = require('fs').readFileSync(require('path').join(process.cwd(), args[1]), "utf8");
     } else {
         var cwd = require("file").path(require("file").cwd());
         var source = cwd.join(args[1]).read({charset: "utf-8"});

--- a/test.html
+++ b/test.html
@@ -4,7 +4,6 @@
 		<script src="js/dummyconsole.js" type="text/javascript" charset="utf-8"></script>
 
 		<!-- third party libraries -->
-		<script type="text/javascript" src="js/webtoolkit.js"></script>
 		<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.5.1/jquery.min.js"></script>
 		<script src="js/json2.js" type="text/javascript" charset="utf-8"></script>
 		<script src="js/beautify.js" type="text/javascript" charset="utf-8"></script>
@@ -125,9 +124,9 @@
 "/*"                  { this.begin('BLOCKCOMMENT'); }
 
 
-<LINECOMMENT>[\n\r]   { console.log('endlinecomment'); this.popState(); }
+<LINECOMMENT>[\n\r]   { this.popState(); }
 <LINECOMMENT>.        {}
-"##"                  { console.log('beginlinecomment'); this.begin('LINECOMMENT'); }
+"##"                  { this.begin('LINECOMMENT'); }
 
 "${{"                 { this.begin('JS'); return "OPENJS"; }
 <JS>"}}$"             { this.popState(); return 'ENDJS'; }
@@ -216,6 +215,7 @@
 ")"                   return ')'
 
 "."                  return '.'
+"`"                   return '`'
 
 "$"[0-9]+             return '$ARG'
 "$"                   return '$ARGS'
@@ -278,6 +278,8 @@ lvalue
         { $$ = $1 + '.get("' + $3 + '")' }
     | '(' lvalue ')'
         { $$ = $2; }
+    | '`' expression '`'
+        { $$ = yy.dobservable($2); }
 
 // XXX: this introduces some shift reduce conflicts apparently, but not sure what the conflict output means
 // so not sure where to look for problems
@@ -352,7 +354,7 @@ expression
 
 // XXX: introduces a TON of SR conflicts and I have no idea why!
     | expression '//' expression
-        { $$ = $1 + ' + ' + $3; }
+        { $$ = $1 + '.concat(' + $3 +')'; }
 
     //
     // assignment operators
@@ -499,7 +501,7 @@ statement
     ;
 
 else-opt
-    : 'ELSE' statement
+    : ELSE statement
         { $$ = ' else ' + $statement; }
     |
         { $$ = ''; }
@@ -650,14 +652,12 @@ formula-definition
     <div id="productions"></div> 
     <div id="table"></div>
 
-
 	<h2>Test the parser</h2>
 	<textarea id="source" rows="8" cols="80"></textarea>
 	<p>
 		<button id="parse_btn">Parse</button>
 		<select id="sample_select"></select>
 		<button id="load_sample_btn">Load Sample</button>
-		<button id="download_btn">Download parser</button>
 	</p>
 
 	<h2>Generated JavaScript</h2>


### PR DESCRIPTION
`[1] // [2];` is now correctly translated to `[1].concat([2]);`

I also ran build.sh to regenerate the parser
